### PR TITLE
Add \{ and \} like libass

### DIFF
--- a/tests/test_ass_parser.py
+++ b/tests/test_ass_parser.py
@@ -8,6 +8,24 @@ import ass_tag_analyzer
     "text,expected_result",
     [
         (
+            "\\{\\}",
+            [
+                ass_tag_analyzer.AssText("{}"),
+            ],
+        ),
+        (
+            "\\{}",
+            [
+                ass_tag_analyzer.AssText("{}"),
+            ],
+        ),
+        (
+            "\\{\\\\}",
+            [
+                ass_tag_analyzer.AssText("{\\}"),
+            ],
+        ),
+        (
             "{\\}test",
             [
                 ass_tag_analyzer.AssTagListOpening(),


### PR DESCRIPTION
\\{ and \\} insert literal braces instead of starting or ending an override block.
From: https://fansubbers.miraheze.org/wiki/List_of_ASS_gotchas