### PR TITLE
Fix SyntaxWarning introduced in Python 3.14

### DIFF
--- a/ass_tag_analyzer/ass_type_parser.py
+++ b/ass_tag_analyzer/ass_type_parser.py
@@ -9,10 +9,10 @@ class TypeParser:
 
     """
     From python documentation
-        \s
+        \\s
             For Unicode (str) patterns:
-                [...]. If the ASCII flag is used, only [ \t\n\r\f\v] is matched.
-        \d
+                [...]. If the ASCII flag is used, only [ \\t\\n\\r\\f\\v] is matched.
+        \\d
             For Unicode (str) patterns:
                 [...]. If the ASCII flag is used only [0-9] is matched.
     Libass


### PR DESCRIPTION
Fix this warning:
ass_tag_analyzer\ass_type_parser.py:12: SyntaxWarning: "\s" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\s"? A raw string is also an option.
  \s